### PR TITLE
Expand text widget testing helpers

### DIFF
--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -1260,14 +1260,19 @@ class TextArea(Widget):
         return state[self.id]  # type: ignore
 
     def input(self, v: str) -> TextArea:
-        """
-        Set the value of the widget only if the value does not exceed the\
-        maximum allowed characters.
-        """
-        # TODO: should input be setting or appending?
+        """Set the value of the widget if within the ``max_chars`` limit."""
         if self.max_chars and len(v) > self.max_chars:
             return self
         return self.set_value(v)
+
+    def append(self, v: str) -> TextArea:
+        """Append text to the current value respecting ``max_chars``."""
+        current = self.value or ""
+        return self.input(current + v)
+
+    def clear(self) -> TextArea:
+        """Clear the widget's value."""
+        return self.set_value("")
 
 
 @dataclass(repr=False)
@@ -1312,14 +1317,19 @@ class TextInput(Widget):
         return state[self.id]  # type: ignore
 
     def input(self, v: str) -> TextInput:
-        """
-        Set the value of the widget only if the value does not exceed the\
-        maximum allowed characters.
-        """
-        # TODO: should input be setting or appending?
+        """Set the value of the widget if within the ``max_chars`` limit."""
         if self.max_chars and len(v) > self.max_chars:
             return self
         return self.set_value(v)
+
+    def append(self, v: str) -> TextInput:
+        """Append text to the current value respecting ``max_chars``."""
+        current = self.value or ""
+        return self.input(current + v)
+
+    def clear(self) -> TextInput:
+        """Clear the widget's value."""
+        return self.set_value("")
 
 
 TimeValue: TypeAlias = Union[time, datetime]
@@ -1439,7 +1449,11 @@ class FileUploader(Widget):
     @property
     def value(self) -> UploadedFile | list[UploadedFile] | None:
         if self._files is not None:
-            return self._files if self.multiple_files else (self._files[0] if self._files else None)
+            return (
+                self._files
+                if self.multiple_files
+                else (self._files[0] if self._files else None)
+            )
         state = self.root.session_state
         assert state
         return state[self.id]  # type: ignore

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -831,6 +831,11 @@ def test_text_area():
     assert sr2.text_area[0].value == long_string
     assert sr2.text_area[1].value == "default"
 
+    sr3 = sr2.text_area[0].append("!!").run()
+    assert sr3.text_area[0].value == long_string + "!!"
+    sr4 = sr3.text_area[0].clear().run()
+    assert sr4.text_area[0].value == ""
+
     repr(sr.text_area[0])
 
 
@@ -854,6 +859,11 @@ def test_text_input():
 
     assert sr2.text_input[0].value == long_string
     assert sr2.text_input[1].value == "default"
+
+    sr3 = sr2.text_input[0].append("!!").run()
+    assert sr3.text_input[0].value == long_string + "!!"
+    sr4 = sr3.text_input[0].clear().run()
+    assert sr4.text_input[0].value == ""
 
     repr(sr.text_input[0])
 


### PR DESCRIPTION
## Summary
- add `append` and `clear` helpers to `TextArea` and `TextInput`
- test the new helpers

## Testing
- `python -m pytest -q -c /dev/null -p no:cov lib/tests/streamlit/testing/element_tree_test.py::test_text_area lib/tests/streamlit/testing/element_tree_test.py::test_text_input`

------
https://chatgpt.com/codex/tasks/task_e_687897781f108327bb1ec7dd598e4fe4