### PR TITLE
Expose testing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,27 @@ Streamlit comes in with [a ton of additional powerful elements](https://docs.str
 
 Our vibrant creators community also extends Streamlit capabilities using  🧩 [Streamlit Components](https://streamlit.io/components).
 
+## Testing Streamlit apps
+
+You can programmatically drive Streamlit apps in your tests using
+``st.testing.v1.AppTest``. This makes it easy to simulate user interactions
+with widgets and assert against the resulting output.
+
+```python
+from streamlit.testing.v1 import AppTest
+
+def test_simple_app():
+    def app():
+        import streamlit as st
+
+        name = st.text_input("Name")
+        st.write("Hello", name)
+
+    at = AppTest.from_function(app).run()
+    at.text_input[0].set_value("World").run()
+    assert at.markdown[0].value == "Hello World"
+```
+
 ## Get inspired
 
 There's so much you can build with Streamlit:

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -312,3 +312,11 @@ experimental_set_query_params = _deprecate_func_name(
 # import in the very end to avoid partially-initialized module import errors, because
 # streamlit.components.v1 also uses some streamlit imports
 import streamlit.components.v1  # noqa: F401
+
+# Public testing interface
+from types import SimpleNamespace as _SimpleNamespace
+import streamlit.testing as _testing
+
+# ``testing`` exposes helpers for writing pytest based tests against
+# Streamlit apps. For now we only expose versioned APIs.
+testing = _SimpleNamespace(v1=_testing.v1)


### PR DESCRIPTION
## Summary
- make `st.testing.v1` accessible via `st.testing`
- document using `AppTest` for pytest-based testing

## Testing
- `pre-commit run --files README.md lib/streamlit/__init__.py`
- `pytest lib/tests/streamlit/testing/app_test_test.py::test_smoke -q` *(fails: ModuleNotFoundError: No module named 'streamlit.proto.RootContainer_pb2')*

------
https://chatgpt.com/codex/tasks/task_e_687899cd549483278dd710b573493765