### PR TITLE
Add rating widget alias

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -231,6 +231,7 @@ text = _main.text
 text_area = _main.text_area
 text_input = _main.text_input
 toggle = _main.toggle
+rating = _main.rating
 time_input = _main.time_input
 title = _main.title
 vega_lite_chart = _main.vega_lite_chart

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -81,6 +81,7 @@ from streamlit.elements.vega_charts import VegaChartsMixin
 from streamlit.elements.widgets.audio_input import AudioInputMixin
 from streamlit.elements.widgets.button import ButtonMixin
 from streamlit.elements.widgets.button_group import ButtonGroupMixin
+from streamlit.elements.widgets.rating import RatingMixin
 from streamlit.elements.widgets.camera_input import CameraInputMixin
 from streamlit.elements.widgets.chat import ChatMixin
 from streamlit.elements.widgets.checkbox import CheckboxMixin
@@ -174,6 +175,7 @@ class DeltaGenerator(
     BokehMixin,
     ButtonMixin,
     ButtonGroupMixin,
+    RatingMixin,
     CameraInputMixin,
     ChatMixin,
     CheckboxMixin,

--- a/lib/streamlit/elements/widgets/rating.py
+++ b/lib/streamlit/elements/widgets/rating.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from streamlit.elements.lib.layout_utils import Width
+from streamlit.elements.lib.utils import Key
+from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.state import WidgetArgs, WidgetCallback, WidgetKwargs
+from streamlit.elements.widgets.button_group import ButtonGroupMixin
+
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
+
+
+class RatingMixin(ButtonGroupMixin):
+    """Display a star rating widget."""
+
+    @gather_metrics("rating")
+    def rating(
+        self,
+        *,
+        key: Key | None = None,
+        disabled: bool = False,
+        on_change: WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        width: Width = "content",
+    ) -> int | None:
+        return self.feedback(
+            "stars",
+            key=key,
+            disabled=disabled,
+            on_change=on_change,
+            args=args,
+            kwargs=kwargs,
+            width=width,
+        )
+
+    @property
+    def dg(self) -> DeltaGenerator:
+        """Get our DeltaGenerator."""
+        return cast("DeltaGenerator", self)

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -489,6 +489,12 @@ class AppTest:
         return self._tree.button_group
 
     @property
+    def rating(self) -> WidgetList[ButtonGroup[Any]]:
+        """Sequence of all ``st.rating`` widgets."""
+
+        return self._tree.button_group
+
+    @property
     def caption(self) -> ElementList[Caption]:
         """Sequence of all ``st.caption`` elements.
 

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -1749,6 +1749,10 @@ class Block:
         return WidgetList(self.get("button_group"))  # type: ignore
 
     @property
+    def rating(self) -> WidgetList[ButtonGroup[Any]]:
+        return WidgetList(self.get("button_group"))  # type: ignore
+
+    @property
     def caption(self) -> ElementList[Caption]:
         return ElementList(self.get("caption"))  # type: ignore
 

--- a/lib/tests/streamlit/element_mocks.py
+++ b/lib/tests/streamlit/element_mocks.py
@@ -71,6 +71,7 @@ WIDGET_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
     ("file_uploader", lambda: st.file_uploader("Upload me")),
     # selectors
     ("feedback", lambda: st.feedback()),
+    ("rating", lambda: st.rating()),
     ("multiselect", lambda: st.multiselect("Show me", ["a", "b", "c"])),
     ("number_input", lambda: st.number_input("Enter a number")),
     ("radio", lambda: st.radio("Choose me", ["a", "b", "c"])),

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -244,6 +244,11 @@ class TestFeedbackCommand(DeltaGeneratorTestCase):
         val = st.feedback("thumbs", key="feedback_command_key")
         assert val == session_state_index
 
+    def test_rating_alias(self):
+        st.rating()
+        delta = self.get_delta_from_queue().new_element.button_group
+        assert [o.content_icon for o in delta.options] == [_STAR_ICON] * 5
+
 
 def get_command_matrix(
     test_args: list[Any], with_st_feedback: bool = False


### PR DESCRIPTION
## Summary
- add `RatingMixin` widget that leverages existing feedback stars
- expose `st.rating` API and connect to testing utilities
- support rating in the element mocks and tests

## Testing
- `pytest lib/tests/streamlit/elements/button_group_test.py::TestFeedbackCommand::test_rating_alias -q` *(fails: ModuleNotFoundError: No module named 'streamlit.proto.RootContainer_pb2')*

------
https://chatgpt.com/codex/tasks/task_e_687d22c394648327b5ed692f3946d1ae